### PR TITLE
Update URL encoding to reflect arbitrum as chain

### DIFF
--- a/components/sections/tokenholders/get-token.tsx
+++ b/components/sections/tokenholders/get-token.tsx
@@ -16,7 +16,7 @@ const GetTokenSection = ({ title, card1, card2 }) => {
         label: card1.ctaText,
         isLink: true,
         isExternal: true,
-        href: "https://app.uniswap.org/#/swap?outputCurrency=0x289ba1701C2F088cf0faf8B3705246331cB8A839",
+        href: "https://app.uniswap.org/swap?outputCurrency=0x289ba1701C2F088cf0faf8B3705246331cB8A839&chain=arbitrum",
       },
       accent: "primary",
       headerIllustration: <StakeTokenSvg />,


### PR DESCRIPTION
Encoded chain variable as arbitrum in the URL so that LPT shows correctly.