### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -211,7 +211,7 @@ module.exports = withPlugins([
           },
           {
             source: "/discord",
-            destination: "https://discord.gg/VGSkNK8AA6",
+            destination: "https://discord.gg/livepeer",
             permanent: false,
           }
         ];


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring)
link to a fixed (permanent) one to ensure long-term accessibility.
